### PR TITLE
Remove HybridMethod descriptor

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -47,14 +47,11 @@ confidence=
 # --disable=W"
 
 # Disable F0401 to hide issues with Pylint importing modules
-# Disable E0213 to hide Pylint confusion of the self/cls argument when using
-# the HybridMethod decorator.
-# Disable E1003 to hide Pylint confusion of the super() call when used in a
-# HybridMethod.
 # Disable W0622 to hide Pylint complaints related to pycompat.
 # Disble R0201 to hide Pylint complaints related to default option coerce func.
 # Disable W0122 to hide Pylint complaints related to using exec in PythonFiles.
-disable=F0401,E0213,E1003,W0622,R0201,W0122
+# Disable E1101 to hide Pylint complains related to missing attr in pycompat.
+disable=F0401,W0622,R0201,W0122,E1101
 
 
 [MISCELLANEOUS]
@@ -131,7 +128,7 @@ generated-members=
 spelling-dict=en_US
 
 # List of comma separated words that should not be checked.
-spelling-ignore-words=config,namespace,iterable,json,ini,regex,namespaces,str,JSON,INI,init,confpy,behaviour,setattr,getattr,classmethod,instancemethod,dict,bool,metadata,iteritems,args,kwargs,cls,iter,subclass,subclasses,api,API,unicode
+spelling-ignore-words=config,namespace,iterable,json,ini,regex,namespaces,str,JSON,INI,init,confpy,behaviour,setattr,getattr,classmethod,instancemethod,dict,bool,metadata,iteritems,args,kwargs,cls,iter,subclass,subclasses,api,API,unicode,_namespaces,NAMESPACES,_NAMESPACES
 
 # A path to a file that contains private dictionary; one word per line.
 spelling-private-dict-file=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - pip install -rtest-requirements.txt
     - pip install -e ./
 script:
-    - pep8 confpy/
-    - pyflakes confpy/
-    - pylint --rcfile=.pylintrc confpy/
+    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[3-4].*) ]]; then pep8 confpy/; else echo "Skipping PEP8 for $(python --version 2>&1)."; fi
+    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[3-4].*) ]]; then pyflakes confpy/; else echo "Skipping PyFlakes for $(python --version 2>&1)."; fi
+    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[3-4].*) ]]; then pylint --rcfile=.pylintrc confpy/; else echo "Skipping PyLint for $(python --version 2>&1)."; fi
     - py.test tests/

--- a/confpy/core/descriptor.py
+++ b/confpy/core/descriptor.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import functools
-
 
 def is_descriptor(obj):
     """True if the object is a descriptor else False."""
@@ -15,60 +13,6 @@ def is_descriptor(obj):
         hasattr(obj, '__set__') or
         hasattr(obj, '__delete__')
     )
-
-
-class HybridMethod(object):
-
-    """Decorator to create combined classmethod and instancemethod."""
-
-    def __init__(self, method):
-        self._method = method
-
-    def __get__(self, obj=None, objtype=None):
-        @functools.wraps(self._method)
-        def wrapper(*args, **kwargs):
-            """Wrap the method and pass in cls or self."""
-            return self._method(obj or objtype, *args, **kwargs)
-        return wrapper
-
-
-class HybridProperty(object):
-
-    """Decorator to create combined class and instance property."""
-
-    def __init__(self, fget, fset=None, fdel=None, fdoc=None):
-        """Initialize the property as a stand-in for @property."""
-        self._fget = fget
-        self._fset = fset
-        self._fdel = fdel
-        self.__doc__ = fdoc or fget.__doc__
-
-    def __get__(self, obj=None, objtype=None):
-        return self._fget(obj or objtype)
-
-    def __set__(self, obj, value):
-        if not self._fset:
-
-            raise AttributeError("can't set attribute")
-
-        self._fset.__get__(obj, type(obj))(value)
-
-    def __delete__(self, obj):
-        if not self._fdel:
-
-            raise AttributeError("can't delete attribute")
-
-        self._fdel.__get__(obj, type(obj))()
-
-    def setter(self, func):
-        """Stand-in for @property.setter."""
-        self._fset = func
-        return self
-
-    def deleter(self, func):
-        """Stand-in for @property.deleter."""
-        self._fdel = func
-        return self
 
 
 class LateDescriptorBinding(object):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('LICENSE', 'r') as licensefile:
 
 setup(
     name='confpy',
-    version='0.1.0',
+    version='0.2.0',
     url='https://github.com/kevinconway/confpy',
     description='Config file parsing and option management.',
     author="Kevin Conway",

--- a/tests/config_files/conf.py
+++ b/tests/config_files/conf.py
@@ -1,2 +1,2 @@
 from confpy.core import config
-config.Configuration.test_python_parse.python_loaded = True
+config.Configuration().test_python_parse.python_loaded = True

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import pytest
+
 from confpy.core import config
 from confpy.core import namespace
 
@@ -20,25 +22,18 @@ def test_config_instance_namespace_setting():
     assert conf.test.description == "test"
 
 
-def test_config_class_namespace_setting():
-    """Test that namespaces are bound to a config after init."""
-    ns = namespace.NameSpace(description="class test")
-    config.Configuration.class_test = ns
-    config.Configuration.class_test = ns
+def test_config_subclasses_are_not_affected_by_parent():
+    """Test that Configuration subclasses to not recieve parent namespaces."""
+    ns = namespace.NameSpace(description="modified")
+    class TestConfiguration(config.Configuration):
+        _NAMESPACES = {}
 
-    assert config.Configuration.class_test is ns
-    assert config.Configuration.class_test.description == "class test"
+    parent = config.Configuration(
+        modified=ns,
+    )
+    child = TestConfiguration()
 
+    assert parent.modified is ns
+    with pytest.raises(AttributeError):
 
-def test_config_combo_namespaces():
-    """Test that both instances and the class can reach namespaces."""
-    set_by_class = namespace.NameSpace()
-    set_by_instance = namespace.NameSpace()
-    config.Configuration.set_by_class = set_by_class
-    instance = config.Configuration(set_by_instance=set_by_instance)
-
-    assert instance.set_by_instance is set_by_instance
-    assert instance.set_by_class is set_by_class
-
-    assert config.Configuration.set_by_class is set_by_class
-    assert config.Configuration.set_by_instance is set_by_instance
+        child.modified

--- a/tests/core/test_descriptor.py
+++ b/tests/core/test_descriptor.py
@@ -23,20 +23,6 @@ class TestDescriptor(object):
         self._value = False
 
 
-def test_hybrid_method():
-    """Test that HybridMethods work for both classes and instances."""
-    class T(object):
-
-        @descriptor.HybridMethod
-        def test(ref):
-            return ref
-
-    assert T.test() is T
-
-    instance = T()
-    assert instance.test() is instance
-
-
 def test_late_descriptor_binding():
     """Test that the LateDescriptorBinding base binds late descriptors."""
     test_value = object()

--- a/tests/loaders/test_python_loader.py
+++ b/tests/loaders/test_python_loader.py
@@ -20,9 +20,10 @@ def conf_body():
     """Return a static configuration file body."""
     return """
 from confpy.core import config
-config.Configuration.test_python_loader.test = True
-config.Configuration.test_python_loader.many = 10
-config.Configuration.test_python_loader.letter = 'a'
+cfg = config.Configuration()
+cfg.test_python_loader.test = True
+cfg.test_python_loader.many = 10
+cfg.test_python_loader.letter = 'a'
 """
 
 


### PR DESCRIPTION
This feature was used to treat the Configuration object like a global
singleton. This ended up creating a more confusing interface. It also
made it difficult to create subclasses, for testing or other purposes,
which are not affected by changes in the parent.

Instead, each instance of Configuration will now share a class dict
which stores the namespaces.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>