### PR TITLE
Fix bug in ListOption constructor

### DIFF
--- a/confpy/options/listopt.py
+++ b/confpy/options/listopt.py
@@ -28,16 +28,17 @@ class ListOption(opt.Option):
             TypeError: If the given option is not an instance of option.Option.
             TypeError: If the default value is set but not an iterable.
         """
+        super(ListOption, self).__init__(*args, **kwargs)
         if not isinstance(option, opt.Option):
 
             raise TypeError("Option must be an option type.")
 
+        self._option = option
+        self._default = default
+
         if default is not None:
 
             self._value = self.coerce(default)
-
-        self._option = option
-        super(ListOption, self).__init__(*args, **kwargs)
 
     def coerce(self, values):
         """Convert an iterable of literals to an iterable of options.
@@ -88,6 +89,6 @@ class ListOption(opt.Option):
         value = self._value
         if not self.required and self._value is None:
 
-            value = self.default
+            value = self.coerce(self._default)
 
         return (val.__get__(None, None) for val in value)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='confpy',
-    version='0.9.1',
+    version='0.9.2',
     url='https://github.com/kevinconway/confpy',
     description='Config file parsing and option management.',
     author="Kevin Conway",

--- a/tests/options/test_listopt.py
+++ b/tests/options/test_listopt.py
@@ -35,3 +35,17 @@ def test_list_string_coerce():
     assert result[1] is False
     assert result[2] is True
     assert result[3] is False
+
+
+def test_list_default():
+    """Test if default values are registered with a list option."""
+    opt = listopt.ListOption(
+        option=boolopt.BoolOption(),
+        default='true,false,yes,no',
+    )
+
+    result = tuple(opt.__get__())
+    assert result[0] is True
+    assert result[1] is False
+    assert result[2] is True
+    assert result[3] is False

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py26,py27,py32,py33,py34,pep8,pyflakes,pylint
 
 [testenv]
 deps=
-    -rrequirements.txt
     -rtest-requirements.txt
 commands=py.test tests/
 


### PR DESCRIPTION
The super() call was out of place causing the default value to
be None regardless of what it was set to.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>