### PR TITLE
Fix bug related to deepcopy of PatternOption

### DIFF
--- a/confpy/options/stropt.py
+++ b/confpy/options/stropt.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
 import re
 
 from ..core import compat
@@ -90,3 +91,20 @@ class PatternOption(option.Option):
             )
 
         return value
+
+    def __deepcopy__(self, memo):
+        """Deep copy an PatternOption.
+
+        This implementation accounts for the regex in the class which cannot
+        be deep copied normally.
+        """
+        new_instance = type(self)(pattern=self._pattern)
+        for key, value in self.__dict__.items():
+
+            if key == '_re':
+
+                continue
+
+            new_instance.__dict__[key] = copy.deepcopy(value, memo)
+
+        return new_instance

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='confpy',
-    version='0.9.2',
+    version='0.9.3',
     url='https://github.com/kevinconway/confpy',
     description='Config file parsing and option management.',
     author="Kevin Conway",

--- a/tests/options/test_stropt.py
+++ b/tests/options/test_stropt.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
+
 import pytest
 
 from confpy.options import stropt
@@ -34,10 +36,17 @@ def test_pattern_coerce():
     assert opt.__get__() == 'c'
 
 
-def test_pattern_coerce_faile():
+def test_pattern_coerce_fail():
     """Test if ValueError is raised when text does not match the pattern."""
     opt = stropt.PatternOption(pattern='[a-z]')
 
     with pytest.raises(ValueError):
 
         opt.__set__(None, '1')
+
+def test_pattern_deepcopy():
+    """Test if PatternOption can be deepcopied for ListOption."""
+    opt = stropt.PatternOption(pattern='[a-z]')
+    new_opt = copy.deepcopy(opt)
+
+    assert new_opt is not opt


### PR DESCRIPTION
The PatternOption contains a regex which cannot be deep copied.
This patch adds a work around.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>