### PR TITLE
Add non-strict parsing mode for ignoring options

### DIFF
--- a/confpy/loaders/base.py
+++ b/confpy/loaders/base.py
@@ -16,9 +16,10 @@ class ConfigurationFile(object):
 
     """Base class for configuration file parsers."""
 
-    def __init__(self, path):
+    def __init__(self, path, strict=True):
         self._path = path
         self._content = None
+        self._strict = strict
 
     @property
     def path(self):
@@ -50,6 +51,10 @@ class ConfigurationFile(object):
 
             if not hasattr(conf, namespace):
 
+                if not self._strict:
+
+                    continue
+
                 raise exc.NamespaceNotRegistered(
                     "The namespace {0} is not registered.".format(namespace)
                 )
@@ -59,6 +64,10 @@ class ConfigurationFile(object):
             for item, value in compat.iteritems(self.items(namespace)):
 
                 if not hasattr(name, item):
+
+                    if not self._strict:
+
+                        continue
 
                     raise exc.OptionNotRegistered(
                         "The option {0} is not registered.".format(item)

--- a/confpy/parser.py
+++ b/confpy/parser.py
@@ -22,7 +22,7 @@ FILE_TYPES = {
 }
 
 
-def configfile_from_path(path):
+def configfile_from_path(path, strict=True):
     """Get a ConfigFile object based on a file path.
 
     This method will inspect the file extension and return the appropriate
@@ -30,6 +30,7 @@ def configfile_from_path(path):
 
     Args:
         path (str): The file path which represents the configuration file.
+        strict (bool): Whether or not to parse the file in strict mode.
 
     Returns:
         confpy.loaders.base.ConfigurationFile: The subclass which is
@@ -49,15 +50,16 @@ def configfile_from_path(path):
             )
         )
 
-    return conf_type(path=path)
+    return conf_type(path=path, strict=strict)
 
 
-def configuration_from_paths(paths):
+def configuration_from_paths(paths, strict=True):
     """Get a Configuration object based on multiple file paths.
 
     Args:
         paths (iter of str): An iterable of file paths which identify config
             files on the system.
+        strict (bool): Whether or not to parse the files in strict mode.
 
     Returns:
         confpy.core.config.Configuration: The loaded configuration object.
@@ -71,7 +73,7 @@ def configuration_from_paths(paths):
     """
     for path in paths:
 
-        cfg = configfile_from_path(path).config
+        cfg = configfile_from_path(path, strict=strict).config
 
     return cfg
 
@@ -194,7 +196,7 @@ def check_for_missing_options(config):
     return config
 
 
-def parse_options(files, env_prefix='CONFPY'):
+def parse_options(files, env_prefix='CONFPY', strict=True):
     """Parse configuration options and return a configuration object.
 
     Args:
@@ -203,6 +205,7 @@ def parse_options(files, env_prefix='CONFPY'):
             overwriting values in earlier files.
         env_prefix (str): The static prefix prepended to all options when set
             as environment variables. The default is CONFPY.
+        strict (bool): Whether or not to parse the files in strict mode.
 
     Returns:
         confpy.core.config.Configuration: The loaded configuration object.
@@ -220,6 +223,7 @@ def parse_options(files, env_prefix='CONFPY'):
             config=set_environment_var_options(
                 config=configuration_from_paths(
                     paths=files,
+                    strict=strict,
                 ),
                 prefix=env_prefix,
             ),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='confpy',
-    version='0.9.3',
+    version='0.10.0',
     url='https://github.com/kevinconway/confpy',
     description='Config file parsing and option management.',
     author="Kevin Conway",

--- a/tests/loaders/test_ini_loader.py
+++ b/tests/loaders/test_ini_loader.py
@@ -27,6 +27,17 @@ letter = a
 
 
 @pytest.fixture
+def conf_body_non_strict():
+    """Return a static configuration file body."""
+    return """
+[test_ini_loader_non_strict]
+test = yes
+many = 10
+letter = a
+    """
+
+
+@pytest.fixture
 def IniFile(conf_body):
     """Return an IniFile class which has a fixture for the content property."""
     class IniTestFile(ini.IniFile):
@@ -34,6 +45,18 @@ def IniFile(conf_body):
         @property
         def content(self):
             return conf_body
+
+    return IniTestFile
+
+
+@pytest.fixture
+def IniFileNonStrict(conf_body_non_strict):
+    """Return an IniFile class which has a fixture for the content property."""
+    class IniTestFile(ini.IniFile):
+
+        @property
+        def content(self):
+            return conf_body_non_strict
 
     return IniTestFile
 
@@ -52,3 +75,17 @@ def test_ini_file_creates_config_objects(IniFile):
     assert generated_conf.test_ini_loader.test is True
     assert generated_conf.test_ini_loader.many == 10
     assert generated_conf.test_ini_loader.letter == 'a'
+
+
+def test_ini_file_creates_config_objects_non_strict(IniFileNonStrict):
+    """Test that parsing INI files loads options."""
+    config.Configuration(
+        test_ini_loader_non_strict=namespace.Namespace(
+            test=boolopt.BoolOption(),
+            many=numopt.IntegerOption(),
+        ),
+    )
+    generated_conf = IniFileNonStrict(path='test', strict=False).config
+
+    assert generated_conf.test_ini_loader_non_strict.test is True
+    assert generated_conf.test_ini_loader_non_strict.many == 10

--- a/tests/loaders/test_json_loader.py
+++ b/tests/loaders/test_json_loader.py
@@ -30,6 +30,20 @@ def conf_body():
 
 
 @pytest.fixture
+def conf_body_non_strict():
+    """Return a static configuration file body."""
+    return """
+    {
+        "test_json_loader_non_strict": {
+            "test": true,
+            "many": 10,
+            "letter": "a"
+        }
+    }
+    """
+
+
+@pytest.fixture
 def JsonFile(conf_body):
     """Return a JsonFile class which has a fixture for the content property."""
     class JsonTestFile(json.JsonFile):
@@ -37,6 +51,18 @@ def JsonFile(conf_body):
         @property
         def content(self):
             return conf_body
+
+    return JsonTestFile
+
+
+@pytest.fixture
+def JsonFileNonScript(conf_body_non_strict):
+    """Return a JsonFile class which has a fixture for the content property."""
+    class JsonTestFile(json.JsonFile):
+
+        @property
+        def content(self):
+            return conf_body_non_strict
 
     return JsonTestFile
 
@@ -55,3 +81,17 @@ def test_json_file_creates_config_objects(JsonFile):
     assert generated_conf.test_json_loader.test is True
     assert generated_conf.test_json_loader.many == 10
     assert generated_conf.test_json_loader.letter == 'a'
+
+
+def test_json_file_creates_config_objects_non_strict(JsonFileNonScript):
+    """Test that parsing JSON files loads options."""
+    config.Configuration(
+        test_json_loader_non_strict=namespace.Namespace(
+            test=boolopt.BoolOption(),
+            many=numopt.IntegerOption(),
+        ),
+    )
+    generated_conf = JsonFileNonScript(path='test', strict=False).config
+
+    assert generated_conf.test_json_loader_non_strict.test is True
+    assert generated_conf.test_json_loader_non_strict.many == 10

--- a/tests/loaders/test_python_loader.py
+++ b/tests/loaders/test_python_loader.py
@@ -28,6 +28,18 @@ cfg.test_python_loader.letter = 'a'
 
 
 @pytest.fixture
+def conf_body_non_strict():
+    """Return a static configuration file body."""
+    return """
+from confpy.core import config
+cfg = config.Configuration()
+cfg.test_python_loader_non_strict.test = True
+cfg.test_python_loader_non_strict.many = 10
+cfg.test_python_loader_non_strict.letter = 'a'
+"""
+
+
+@pytest.fixture
 def PythonFile(conf_body):
     """Return a PythonFile class which has a fixture for the content."""
     class PythonTestFile(pyfile.PythonFile):
@@ -35,6 +47,18 @@ def PythonFile(conf_body):
         @property
         def content(self):
             return conf_body
+
+    return PythonTestFile
+
+
+@pytest.fixture
+def PythonFileNonStrict(conf_body_non_strict):
+    """Return a PythonFile class which has a fixture for the content."""
+    class PythonTestFile(pyfile.PythonFile):
+
+        @property
+        def content(self):
+            return conf_body_non_strict
 
     return PythonTestFile
 
@@ -53,3 +77,17 @@ def test_python_file_creates_config_objects(PythonFile):
     assert generated_conf.test_python_loader.test is True
     assert generated_conf.test_python_loader.many == 10
     assert generated_conf.test_python_loader.letter == 'a'
+
+
+def test_python_file_creates_config_objects_non_strict(PythonFileNonStrict):
+    """Test that execing Python files loads options."""
+    config.Configuration(
+        test_python_loader_non_strict=namespace.Namespace(
+            test=boolopt.BoolOption(),
+            many=numopt.IntegerOption(),
+        ),
+    )
+    generated_conf = PythonFileNonStrict(path='test').config
+
+    assert generated_conf.test_python_loader_non_strict.test is True
+    assert generated_conf.test_python_loader_non_strict.many == 10


### PR DESCRIPTION
This option enables the parser to ignore unrecognized options while
still parsing registered options.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>